### PR TITLE
Add local leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ Open `index.html` in your browser or enable GitHub Pages on this repository to p
 
 Use the arrow keys to control the snake. Eat the red apples to grow longer and increase your score. If you collide with yourself the game restarts.
 
+Your highest scores are stored locally and displayed in the leaderboard below the game. Try to beat your personal best!
+
 Enjoy!

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
   <canvas id="game" width="600" height="600"></canvas>
   <button id="start">Start Game</button>
   <p id="score">Score: 0</p>
+  <h2>Leaderboard</h2>
+  <ol id="leaderboard"></ol>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 const scoreEl = document.getElementById('score');
 const startButton = document.getElementById('start');
+const leaderboardEl = document.getElementById('leaderboard');
 
 const gridSize = 20;
 const tileCount = canvas.width / gridSize;
@@ -12,6 +13,34 @@ let apple = { x: 5, y: 5 };
 let growing = 0;
 let score = 0;
 let running = false;
+
+function loadLeaderboard() {
+  const data = localStorage.getItem('leaderboard');
+  return data ? JSON.parse(data) : [];
+}
+
+function saveLeaderboard(scores) {
+  localStorage.setItem('leaderboard', JSON.stringify(scores));
+}
+
+function renderLeaderboard() {
+  const scores = loadLeaderboard();
+  leaderboardEl.innerHTML = '';
+  scores.forEach((s, i) => {
+    const li = document.createElement('li');
+    li.textContent = `${i + 1}. ${s}`;
+    leaderboardEl.appendChild(li);
+  });
+}
+
+function addScore(newScore) {
+  const scores = loadLeaderboard();
+  scores.push(newScore);
+  scores.sort((a, b) => b - a);
+  if (scores.length > 10) scores.length = 10;
+  saveLeaderboard(scores);
+  renderLeaderboard();
+}
 
 function reset() {
   snake = [{ x: 10, y: 10 }];
@@ -32,6 +61,7 @@ function gameLoop(timestamp) {
     draw();
     requestAnimationFrame(gameLoop);
   } else {
+    addScore(score);
     reset();
     running = false;
     startButton.disabled = false;
@@ -113,6 +143,7 @@ window.addEventListener('keydown', e => {
 });
 
 reset();
+renderLeaderboard();
 startButton.addEventListener('click', () => {
   startButton.disabled = true;
   running = true;

--- a/style.css
+++ b/style.css
@@ -14,6 +14,14 @@ button {
   margin-top: 10px;
 }
 
+#leaderboard {
+  list-style: none;
+  padding: 0;
+  max-width: 200px;
+  margin: 10px auto;
+  text-align: left;
+}
+
 h1 {
   margin-top: 20px;
 }


### PR DESCRIPTION
## Summary
- add leaderboard markup to index
- style leaderboard
- store scores in localStorage and render leaderboard
- mention leaderboard in README

## Testing
- `npx --version` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_683dd563aacc832abd155feaad0aa37c