### PR TITLE
Fix leaderboard names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Then open the provided URL in your browser to play the game locally.
 
 ### Online scores
 
-The game tries to submit scores to `https://example.com/api/scores`. Replace this URL in `script.js` with your own service or remove the calls to disable the feature.
+The game tries to submit scores, including player names, to `https://example.com/api/scores`. Replace this URL in `script.js` with your own service or remove the calls to disable the feature.

--- a/script.js
+++ b/script.js
@@ -100,12 +100,12 @@ async function loadOnlineLeaderboard() {
   }
 }
 
-async function postScoreOnline(score) {
+async function postScoreOnline(scoreData) {
   try {
     await fetch('https://example.com/api/scores', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ score })
+      body: JSON.stringify(scoreData)
     });
   } catch (e) {}
 }
@@ -146,7 +146,9 @@ function renderLeaderboard() {
     leaderboardEl.appendChild(header);
     onlineScores.forEach((s, i) => {
       const li = document.createElement('li');
-      li.textContent = `${i + 1}. ${s}`;
+      li.textContent = s.name
+        ? `${i + 1}. ${s.name}: ${s.score}`
+        : `${i + 1}. ${s}`;
       leaderboardEl.appendChild(li);
     });
   }
@@ -160,7 +162,7 @@ function addScore(newScore) {
   if (list.length > 10) list.length = 10;
   saveLeaderboard(scores);
   renderLeaderboard();
-  postScoreOnline(newScore.score);
+  postScoreOnline(newScore);
 }
 
 function reset() {


### PR DESCRIPTION
## Summary
- display player names in online leaderboard
- send player names when posting scores

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e22ec4c60832a8ee52350c000e6d7