### PR TITLE
Prevent page scrolling during gameplay

### DIFF
--- a/script.js
+++ b/script.js
@@ -272,6 +272,15 @@ function draw() {
 
 window.addEventListener('keydown', e => {
   const key = e.key.toLowerCase();
+  if (
+    key === ' ' ||
+    key === 'arrowup' ||
+    key === 'arrowdown' ||
+    key === 'arrowleft' ||
+    key === 'arrowright'
+  ) {
+    e.preventDefault();
+  }
   switch (key) {
     case 'arrowup':
     case 'w':


### PR DESCRIPTION
## Summary
- block default page scrolling when spacebar or arrow keys are pressed

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683e22f922e0832ab0dc4483828e6932