### PR TITLE
Limit leaderboard height

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,6 +27,8 @@ button {
   max-width: 200px;
   margin: 10px auto;
   text-align: left;
+  max-height: 200px;
+  overflow: hidden;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- prevent leaderboard from extending the page by setting a max height

## Testing
- `bash setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_683e231ecfe4832aab94a53f90947adb