### PR TITLE
Update README for custom backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,11 @@ Then open the provided URL in your browser to play the game locally.
 
 ### Online scores
 
-The game tries to submit scores, including player names, to `https://example.com/api/scores`. Replace this URL in `script.js` with your own service or remove the calls to disable the feature.
+The game tries to submit scores, including player names, to a placeholder
+endpoint.
+
+#### Using a real backend
+
+Open `script.js` and search for `example.com/api/scores`. Replace the placeholder
+URL with the address of your server. Removing the calls to `postScoreOnline`
+will disable online score submission entirely.


### PR DESCRIPTION
## Summary
- document how to change the backend URL
- explain how to disable online score submission

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683e24a8dd5c832abe3b501c2682afec