### PR TITLE
Use SCORE_API constant for leaderboard URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ endpoint.
 
 #### Using a real backend
 
-Open `script.js` and search for `example.com/api/scores`. Replace the placeholder
-URL with the address of your server. Removing the calls to `postScoreOnline`
+Open `script.js` and change the value of the `SCORE_API` constant near the top of
+the file to the address of your server. Removing the calls to `postScoreOnline`
 will disable online score submission entirely.

--- a/script.js
+++ b/script.js
@@ -10,6 +10,9 @@ const pausedEl = document.getElementById('paused');
 const difficultySelect = document.getElementById('difficulty');
 const themeSelect = document.getElementById('theme');
 
+// Online score endpoint
+const SCORE_API = 'https://example.com/api/scores';
+
 // Sound effects
 const eatSound = new Audio('assets/eat.mp3');
 const gameOverSound = new Audio('assets/gameover.mp3');
@@ -94,7 +97,7 @@ let playerName = '';
 
 async function loadOnlineLeaderboard() {
   try {
-    const res = await fetch('https://example.com/api/scores');
+    const res = await fetch(SCORE_API);
     if (res.ok) {
       const data = await res.json();
       onlineScores = data.scores || [];
@@ -106,7 +109,7 @@ async function loadOnlineLeaderboard() {
 
 async function postScoreOnline(scoreData) {
   try {
-    await fetch('https://example.com/api/scores', {
+    await fetch(SCORE_API, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(scoreData)


### PR DESCRIPTION
## Summary
- add a SCORE_API constant near the top of the script
- use the constant in leaderboard network calls
- update README to reference SCORE_API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f188986ec832a815da4318d9a57eb