### PR TITLE
Switch to local http-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Debian/Ubuntu you can install them with:
 sudo apt-get update && sudo apt-get install -y nodejs npm
 ```
 
-Once Node.js is available, run `./setup.sh` to install the `http-server`
-package globally. After running the script you can
-start a local web server with:
+Once Node.js is available, run `./setup.sh` to install the project
+dependencies. After running the script you can start a local web server
+with:
 
 ```bash
-http-server
+npm run serve
 ```
 
 Then open the provided URL in your browser to play the game locally.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "serve": "http-server"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -11,9 +11,7 @@ if ! command -v node >/dev/null 2>&1; then
     exit 1
 fi
 
-# Install http-server globally for serving the project
-if ! command -v http-server >/dev/null 2>&1; then
-    npm install -g http-server
-fi
+# Install project dependencies locally
+npm install
 
-echo "Setup complete. Use 'http-server' to run the game locally."
+echo "Setup complete. Use 'npm run serve' to run the game locally."


### PR DESCRIPTION
## Summary
- install `http-server` locally as a dev dependency
- add a `serve` npm script
- document running the dev server with `npm run serve`
- update `setup.sh` to install dependencies instead of using a global `http-server`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f188e6140832a8ecb95cd1f12cb6f