### PR TITLE
Refactor logic into module and add tests

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,0 +1,32 @@
+export function isOccupied(x, y, snake = [], apples = [], obstacles = []) {
+  for (const part of snake) {
+    if (part.x === x && part.y === y) return true;
+  }
+  for (const a of apples) {
+    if (a.x === x && a.y === y) return true;
+  }
+  for (const o of obstacles) {
+    if (o.x === x && o.y === y) return true;
+  }
+  return false;
+}
+
+export function randomApple(tileCount, snake = [], apples = [], obstacles = []) {
+  let pos;
+  do {
+    pos = {
+      x: Math.floor(Math.random() * tileCount),
+      y: Math.floor(Math.random() * tileCount)
+    };
+  } while (isOccupied(pos.x, pos.y, snake, apples, obstacles));
+  return {
+    x: pos.x,
+    y: pos.y,
+    type: Math.random() < 0.1 ? 'gold' : 'normal'
+  };
+}
+
+export function updateSpeed(snakeLength, difficultySetting) {
+  const min = difficultySetting.minFrame || 40;
+  return Math.max(min, difficultySetting.frame - (snakeLength - 1) * 2);
+}

--- a/index.html
+++ b/index.html
@@ -41,6 +41,6 @@
       <ol id="leaderboard"></ol>
     </div>
   </div>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+import { isOccupied, randomApple, updateSpeed } from './game.js';
+
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 const scoreEl = document.getElementById('score');
@@ -22,33 +24,6 @@ const gridSize = 20;
 const tileCount = canvas.width / gridSize;
 const appleCount = 3;
 
-function isOccupied(x, y) {
-  for (let part of snake) {
-    if (part.x === x && part.y === y) return true;
-  }
-  for (let a of apples) {
-    if (a.x === x && a.y === y) return true;
-  }
-  for (let o of obstacles) {
-    if (o.x === x && o.y === y) return true;
-  }
-  return false;
-}
-
-function randomApple() {
-  let pos;
-  do {
-    pos = {
-      x: Math.floor(Math.random() * tileCount),
-      y: Math.floor(Math.random() * tileCount)
-    };
-  } while (isOccupied(pos.x, pos.y));
-  return {
-    x: pos.x,
-    y: pos.y,
-    type: Math.random() < 0.1 ? 'gold' : 'normal'
-  };
-}
 
 function randomObstacle() {
   let pos;
@@ -57,7 +32,7 @@ function randomObstacle() {
       x: Math.floor(Math.random() * tileCount),
       y: Math.floor(Math.random() * tileCount)
     };
-  } while (isOccupied(pos.x, pos.y));
+  } while (isOccupied(pos.x, pos.y, snake, apples, obstacles));
   return pos;
 }
 
@@ -175,9 +150,9 @@ function reset() {
   apples = [];
   obstacles = [];
   frameDelay = difficultySettings[currentDifficulty].frame;
-  updateSpeed();
+  frameDelay = updateSpeed(snake.length, difficultySettings[currentDifficulty]);
   for (let i = 0; i < appleCount; i++) {
-    apples.push(randomApple());
+    apples.push(randomApple(tileCount, snake, apples, obstacles));
   }
   for (let i = 0; i < difficultySettings[currentDifficulty].obstacles; i++) {
     obstacles.push(randomObstacle());
@@ -193,12 +168,6 @@ function updateScore() {
   scoreEl.textContent = `Score: ${score}`;
 }
 
-function updateSpeed() {
-  const settings = difficultySettings[currentDifficulty];
-  const min = settings.minFrame || 40;
-  const newDelay = Math.max(min, settings.frame - (snake.length - 1) * 2);
-  frameDelay = newDelay;
-}
 
 function gameLoop(timestamp) {
   if (!running) return;
@@ -255,8 +224,8 @@ function step(timestamp) {
       eatSound.currentTime = 0;
       eatSound.play();
       growing += a.type === 'gold' ? 2 : 1;
-      apples[i] = randomApple();
-      updateSpeed();
+      apples[i] = randomApple(tileCount, snake, apples, obstacles);
+      frameDelay = updateSpeed(snake.length, difficultySettings[currentDifficulty]);
     }
   }
 

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -1,0 +1,39 @@
+import { strictEqual, ok } from 'node:assert';
+import test from 'node:test';
+import { isOccupied, randomApple, updateSpeed } from '../game.js';
+
+test('isOccupied detects occupied tiles', () => {
+  const snake = [{ x: 1, y: 1 }];
+  const apples = [{ x: 2, y: 2 }];
+  const obstacles = [{ x: 3, y: 3 }];
+
+  ok(isOccupied(1, 1, snake, apples, obstacles));
+  ok(isOccupied(2, 2, snake, apples, obstacles));
+  ok(isOccupied(3, 3, snake, apples, obstacles));
+  strictEqual(isOccupied(4, 4, snake, apples, obstacles), false);
+});
+
+test('randomApple returns a free position', () => {
+  const snake = [{ x: 0, y: 0 }];
+  const apples = [{ x: 1, y: 1 }];
+  const obstacles = [{ x: 2, y: 2 }];
+  const tileCount = 5;
+
+  const seq = [0, 0, 0.3, 0.4, 0.5];
+  const origRandom = Math.random;
+  let i = 0;
+  Math.random = () => seq[i++];
+
+  const apple = randomApple(tileCount, snake, apples, obstacles);
+
+  Math.random = origRandom;
+
+  strictEqual(isOccupied(apple.x, apple.y, snake, apples, obstacles), false);
+});
+
+test('updateSpeed calculates delay by length', () => {
+  const setting = { frame: 120, minFrame: 60 };
+  strictEqual(updateSpeed(1, setting), 120);
+  strictEqual(updateSpeed(10, setting), 102);
+  strictEqual(updateSpeed(40, setting), 60);
+});


### PR DESCRIPTION
## Summary
- extract game helper functions into `game.js`
- switch `script.js` to import helpers and update calls
- load `script.js` as an ES module in `index.html`
- add tests for `isOccupied`, `randomApple` and `updateSpeed`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f18901bbc832aa7cf005f197cd1a6