### PR TITLE
Refactor functions into module and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+

--- a/game.js
+++ b/game.js
@@ -1,0 +1,38 @@
+// Reusable game functions for Node.js and browser use
+
+export function isOccupied(x, y, snake = [], apples = [], obstacles = []) {
+  for (const part of snake) {
+    if (part.x === x && part.y === y) return true;
+  }
+  for (const a of apples) {
+    if (a.x === x && a.y === y) return true;
+  }
+  for (const o of obstacles) {
+    if (o.x === x && o.y === y) return true;
+  }
+  return false;
+}
+
+export function randomApple(tileCount, snake = [], apples = [], obstacles = [], rng = Math.random) {
+  const maxAttempts = 100;
+  for (let attempts = 0; attempts < maxAttempts; attempts++) {
+    const pos = {
+      x: Math.floor(rng() * tileCount),
+      y: Math.floor(rng() * tileCount)
+    };
+    if (!isOccupied(pos.x, pos.y, snake, apples, obstacles)) {
+      return {
+        x: pos.x,
+        y: pos.y,
+        type: rng() < 0.1 ? 'gold' : 'normal'
+      };
+    }
+  }
+  return null;
+}
+
+export function updateSpeed(length, settings, difficulty) {
+  const cfg = settings[difficulty];
+  const min = cfg.minFrame || 40;
+  return Math.max(min, cfg.frame - (length - 1) * 2);
+}

--- a/index.html
+++ b/index.html
@@ -43,6 +43,6 @@
       <ol id="leaderboard"></ol>
     </div>
   </div>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -1,0 +1,38 @@
+import { strictEqual, ok } from 'node:assert';
+import test from 'node:test';
+import { isOccupied, randomApple, updateSpeed } from '../game.js';
+
+test('isOccupied detects occupied tiles', () => {
+  const snake = [{ x: 1, y: 1 }];
+  const apples = [{ x: 2, y: 2 }];
+  const obstacles = [{ x: 3, y: 3 }];
+  strictEqual(isOccupied(1, 1, snake, apples, obstacles), true);
+  strictEqual(isOccupied(2, 2, snake, apples, obstacles), true);
+  strictEqual(isOccupied(3, 3, snake, apples, obstacles), true);
+  strictEqual(isOccupied(4, 4, snake, apples, obstacles), false);
+});
+
+test('randomApple returns non-colliding position', () => {
+  const snake = [{ x: 0, y: 0 }];
+  const apples = [{ x: 1, y: 1 }];
+  const obstacles = [{ x: 2, y: 2 }];
+  const values = [0,0, 0.2,0.2, 0.4,0.4, 0.6,0.6, 0.5];
+  let i = 0;
+  const rng = () => values[i++];
+  const apple = randomApple(5, snake, apples, obstacles, rng);
+  strictEqual(apple.x, 3);
+  strictEqual(apple.y, 3);
+  strictEqual(apple.type, 'normal');
+  ok(!isOccupied(apple.x, apple.y, snake, apples, obstacles));
+});
+
+test('updateSpeed adjusts delay based on length', () => {
+  const settings = {
+    easy: { frame: 150, obstacles: 0, minFrame: 80 },
+    medium: { frame: 120, obstacles: 5, minFrame: 60 },
+    hard: { frame: 90, obstacles: 10, minFrame: 45 }
+  };
+  strictEqual(updateSpeed(1, settings, 'medium'), 120);
+  strictEqual(updateSpeed(10, settings, 'medium'), 102);
+  strictEqual(updateSpeed(50, settings, 'medium'), 60);
+});


### PR DESCRIPTION
## Summary
- extract `isOccupied`, `randomApple` and `updateSpeed` to new `game.js` module
- convert `script.js` to import these helpers
- mark `script.js` as a module in `index.html`
- add unit tests for new helpers
- ignore `node_modules` and lockfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f19dc3784832a9538e525ca2bf547