### PR TITLE
Add AI-controlled NPC snake

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
         </select>
       </div>
       <p id="score">Score: 0</p>
+      <p id="npc-score">NPC Score: 0</p>
       <h2>Leaderboard</h2>
       <ol id="leaderboard"></ol>
     </div>


### PR DESCRIPTION
## Summary
- add separate NPC score display to HTML
- support NPC color in theme configuration
- implement NPC snake logic and pathing
- spawn apples and obstacles considering NPC

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f1b7f8610832aacfbed0175cc6ca1