### PR TITLE
Add multiple AI opponents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Your highest scores are stored locally and displayed in the leaderboard below th
 - Choose from multiple visual themes.
 - Leaderboards are stored per difficulty and include player names.
 - The theme defaults to dark when your system prefers it.
+- Battle against multiple AI-controlled snakes.
 
 Enjoy!
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         </select>
       </div>
       <p id="score">Score: 0</p>
-      <p id="npc-score">NPC Score: 0</p>
+      <div id="npc-scores"></div>
       <h2>Leaderboard</h2>
       <ol id="leaderboard"></ol>
     </div>


### PR DESCRIPTION
## Summary
- support multiple NPC snakes instead of just one
- update scoreboard to list each NPC
- describe new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f1f189c40832a860b521fb731c051