### PR TITLE
Zoomed-out board

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,7 +24,10 @@ if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').match
   themeSelect.value = 'dark';
 }
 
-const gridSize = 20;
+// Reduce the size of each tile so more of them fit on the
+// canvas. This effectively "zooms out" the board without
+// increasing the canvas size.
+const gridSize = 10;
 const tileCount = canvas.width / gridSize;
 const appleCount = 3;
 const NPC_COUNT = 3;


### PR DESCRIPTION
## Summary
- shrink tile size from 20px to 10px so that more tiles fit on the canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f20753f94832abc5249ac4d4f2ca0