### PR TITLE
Add npm audit step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 package-lock.json
+audit.log
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ sudo apt-get update && sudo apt-get install -y nodejs npm
 ```
 
 Once Node.js is available, run `./setup.sh` to install the project
-dependencies. After running the script you can start a local web server
-with:
+dependencies and perform an `npm audit` while network access is still
+available. The audit results are saved to `audit.log`. After running the
+script you can start a local web server with:
 
 ```bash
 npm run serve

--- a/setup.sh
+++ b/setup.sh
@@ -14,4 +14,11 @@ fi
 # Install project dependencies locally
 npm install
 
+echo "Running npm audit to check for vulnerabilities..."
+if npm audit > audit.log; then
+    echo "Audit complete. Results saved to audit.log."
+else
+    echo "npm audit failed, possibly due to lack of network connectivity."
+fi
+
 echo "Setup complete. Use 'npm run serve' to run the game locally."


### PR DESCRIPTION
## Summary
- run `npm audit` during `setup.sh` when network is available
- record audit results in `audit.log`
- document the audit step in README
- ignore `audit.log` in git

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f25ad88d4832ab72c7f5472a4514b