### PR TITLE
Add mobile touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,13 @@
       </canvas>
       <div id="game-over" style="display:none">Game Over</div>
       <div id="paused" style="display:none">Paused</div>
+      <div id="touch-controls">
+        <button id="btn-up" aria-label="Up">&#8593;</button>
+        <button id="btn-left" aria-label="Left">&#8592;</button>
+        <button id="btn-down" aria-label="Down">&#8595;</button>
+        <button id="btn-right" aria-label="Right">&#8594;</button>
+        <button id="btn-pause" aria-label="Pause">Pause</button>
+      </div>
     </div>
     <div id="sidebar">
       <label for="player-name">Name:</label>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,11 @@ const scoreEl = document.getElementById('score');
 const npcScoresEl = document.getElementById('npc-scores');
 const startButton = document.getElementById('start');
 const pauseButton = document.getElementById('pause');
+const upBtn = document.getElementById('btn-up');
+const downBtn = document.getElementById('btn-down');
+const leftBtn = document.getElementById('btn-left');
+const rightBtn = document.getElementById('btn-right');
+const pauseTouchBtn = document.getElementById('btn-pause');
 const playerNameInput = document.getElementById('player-name');
 const leaderboardEl = document.getElementById('leaderboard');
 const gameOverEl = document.getElementById('game-over');
@@ -593,6 +598,23 @@ function draw() {
   }
 }
 
+function setDirection(dir) {
+  switch (dir) {
+    case 'up':
+      if (velocity.y !== 1) velocity = { x: 0, y: -1 };
+      break;
+    case 'down':
+      if (velocity.y !== -1) velocity = { x: 0, y: 1 };
+      break;
+    case 'left':
+      if (velocity.x !== 1) velocity = { x: -1, y: 0 };
+      break;
+    case 'right':
+      if (velocity.x !== -1) velocity = { x: 1, y: 0 };
+      break;
+  }
+}
+
 window.addEventListener('keydown', e => {
   const key = e.key.toLowerCase();
   if (
@@ -607,23 +629,19 @@ window.addEventListener('keydown', e => {
   switch (key) {
     case 'arrowup':
     case 'w':
-      if (velocity.y === 1) break;
-      velocity = { x: 0, y: -1 };
+      setDirection('up');
       break;
     case 'arrowdown':
     case 's':
-      if (velocity.y === -1) break;
-      velocity = { x: 0, y: 1 };
+      setDirection('down');
       break;
     case 'arrowleft':
     case 'a':
-      if (velocity.x === 1) break;
-      velocity = { x: -1, y: 0 };
+      setDirection('left');
       break;
     case 'arrowright':
     case 'd':
-      if (velocity.x === -1) break;
-      velocity = { x: 1, y: 0 };
+      setDirection('right');
       break;
     case ' ': // spacebar
       fastMode = true;
@@ -703,3 +721,31 @@ pauseButton.addEventListener('click', () => {
     requestAnimationFrame(gameLoop);
   }
 });
+
+function attachTouch(el, dir) {
+  el.addEventListener('touchstart', e => {
+    e.preventDefault();
+    setDirection(dir);
+  });
+  el.addEventListener('touchend', e => e.preventDefault());
+}
+
+if (upBtn) {
+  attachTouch(upBtn, 'up');
+  attachTouch(downBtn, 'down');
+  attachTouch(leftBtn, 'left');
+  attachTouch(rightBtn, 'right');
+}
+
+if (pauseTouchBtn) {
+  pauseTouchBtn.addEventListener('touchstart', e => {
+    e.preventDefault();
+    if (!running) return;
+    paused = !paused;
+    pausedEl.style.display = paused ? 'block' : 'none';
+    if (!paused) {
+      requestAnimationFrame(gameLoop);
+    }
+  });
+  pauseTouchBtn.addEventListener('touchend', e => e.preventDefault());
+}

--- a/style.css
+++ b/style.css
@@ -123,6 +123,43 @@ h1 {
   margin: 0 auto;
 }
 
+#touch-controls {
+  display: grid;
+  grid-template-columns: repeat(3, 60px);
+  grid-template-rows: repeat(3, 60px);
+  gap: 5px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 10px;
+}
+
+#btn-up {
+  grid-column: 2;
+  grid-row: 1;
+}
+#btn-left {
+  grid-column: 1;
+  grid-row: 2;
+}
+#btn-down {
+  grid-column: 2;
+  grid-row: 2;
+}
+#btn-right {
+  grid-column: 3;
+  grid-row: 2;
+}
+#btn-pause {
+  grid-column: 2;
+  grid-row: 3;
+}
+
+@media (min-width: 800px) {
+  #touch-controls {
+    display: none;
+  }
+}
+
 @media (min-width: 800px) {
   #layout {
     flex-direction: row;


### PR DESCRIPTION
## Summary
- add directional touch buttons and mobile pause button
- style touch control layout and hide on large screens
- implement touch event handlers in `script.js`
- refactor keyboard movement handling via `setDirection`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f597c6474832ab75c07cefa370511