### PR TITLE
Add timed apple spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Your highest scores are stored locally and displayed in the leaderboard below th
 - Gold apples worth extra points appear occasionally.
 - Speed apples give a temporary speed boost.
 - Ghost apples let you pass through obstacles briefly.
+- Additional apples appear at random while playing.
 - Difficulty levels adjust speed and add obstacles.
 - Optional timed mode challenges you to score in 60 seconds.
 - Choose from multiple visual themes.

--- a/script.js
+++ b/script.js
@@ -41,6 +41,8 @@ const appleCount = 3;
 const NPC_COUNT = 3;
 const NPC_SPAWN_MIN = 2000; // minimum respawn delay in ms
 const NPC_SPAWN_MAX = 5000; // maximum respawn delay in ms
+const APPLE_SPAWN_MIN = 4000; // minimum new apple delay in ms
+const APPLE_SPAWN_MAX = 7000; // maximum new apple delay in ms
 
 function randomObstacle() {
   const maxAttempts = 100;
@@ -100,6 +102,24 @@ function scheduleNpcSpawn() {
   setTimeout(() => {
     if (!running) return;
     spawnNpc();
+  }, delay);
+}
+
+function scheduleAppleSpawn() {
+  const delay =
+    APPLE_SPAWN_MIN + Math.random() * (APPLE_SPAWN_MAX - APPLE_SPAWN_MIN);
+  setTimeout(() => {
+    if (!running) return;
+    const a = randomApple(
+      tileCount,
+      snake.concat(getAllNpcParts()),
+      apples,
+      obstacles
+    );
+    if (a) {
+      apples.push(a);
+    }
+    scheduleAppleSpawn();
   }, delay);
 }
 let apples = [];
@@ -709,6 +729,7 @@ startButton.addEventListener('click', () => {
     timerEl.style.display = 'none';
   }
   running = true;
+  scheduleAppleSpawn();
   lastTime = 0;
   requestAnimationFrame(gameLoop);
 });


### PR DESCRIPTION
## Summary
- let apples spawn randomly over time while a game is running
- mention new feature in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f5b018abc832a91899d4238e9c454