### PR TITLE
Auto scale difficulty

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple JavaScript implementation of the classic Snake game.
 Open `index.html` in your browser or enable GitHub Pages on this repository to play online.
 
 Use the arrow keys or WASD keys to control the snake. Eat apples to grow longer and increase your score. Some apples are gold and grant bonus points. The snake wraps around when it reaches the edge of the board. Avoid your own tail and the obstacles that appear on higher difficulties.
-Hold the spacebar to temporarily speed up the snake. Press <kbd>p</kbd> to pause or resume the game. Select a difficulty level and theme before starting to customize the experience.
+Hold the spacebar to temporarily speed up the snake. Press <kbd>p</kbd> to pause or resume the game. Difficulty now increases automatically as you score, so just choose a theme before starting.
 You can also enter your name to record it on the local leaderboard and use the on-screen **Pause** button if you prefer the mouse.
 
 Your highest scores are stored locally and displayed in the leaderboard below the game. The game will also try to fetch and submit online scores when possible.

--- a/index.html
+++ b/index.html
@@ -32,12 +32,6 @@
           Use the arrow keys or WASD to move. Hold the spacebar to speed up. Collect blue speed apples for a short boost and purple ghost apples to pass through obstacles briefly. Use the <strong>Pause</strong> button or press <kbd>p</kbd> to pause/resume.
         </div>
       <div id="options">
-        <label for="difficulty">Difficulty:</label>
-        <select id="difficulty">
-          <option value="easy">Easy</option>
-          <option value="medium" selected>Medium</option>
-          <option value="hard">Hard</option>
-        </select>
         <label for="theme">Theme:</label>
         <select id="theme">
           <option value="classic" selected>Classic</option>

--- a/script.js
+++ b/script.js
@@ -15,7 +15,6 @@ const playerNameInput = document.getElementById('player-name');
 const leaderboardEl = document.getElementById('leaderboard');
 const gameOverEl = document.getElementById('game-over');
 const pausedEl = document.getElementById('paused');
-const difficultySelect = document.getElementById('difficulty');
 const themeSelect = document.getElementById('theme');
 const modeSelect = document.getElementById('mode');
 const aiSelect = document.getElementById('ai-behavior');
@@ -134,7 +133,7 @@ const difficultySettings = {
   medium: { frame: 120, obstacles: 5, minFrame: 60 },
   hard: { frame: 90, obstacles: 10, minFrame: 45 }
 };
-let currentDifficulty = 'medium';
+let currentDifficulty = 'easy';
 let frameDelay = difficultySettings[currentDifficulty].frame;
 const fastFrameDelay = 75; // ms when holding spacebar
 let fastMode = false;
@@ -266,6 +265,7 @@ function reset() {
   velocity = { x: 0, y: 0 };
   apples = [];
   obstacles = [];
+  currentDifficulty = 'easy';
   frameDelay = difficultySettings[currentDifficulty].frame;
   frameDelay = calcSpeed(snake.length, difficultySettings, currentDifficulty);
   for (let i = 0; i < appleCount; i++) {
@@ -310,6 +310,25 @@ function updateScore() {
   npcs.forEach((npc, i) => {
     npc.scoreEl.textContent = `NPC ${i + 1} Score: ${npc.score}`;
   });
+}
+
+function updateDifficulty() {
+  let newDiff = 'easy';
+  if (score >= 25) {
+    newDiff = 'hard';
+  } else if (score >= 10) {
+    newDiff = 'medium';
+  }
+  if (newDiff !== currentDifficulty) {
+    currentDifficulty = newDiff;
+    while (obstacles.length < difficultySettings[currentDifficulty].obstacles) {
+      const o = randomObstacle();
+      if (!o) break;
+      obstacles.push(o);
+    }
+    frameDelay = calcSpeed(snake.length, difficultySettings, currentDifficulty);
+    renderLeaderboard();
+  }
 }
 
 function removeNpc(npc) {
@@ -475,6 +494,7 @@ function step(timestamp) {
     if (head.x === a.x && head.y === a.y) {
       score += a.type === 'gold' ? 5 : 1;
       updateScore();
+      updateDifficulty();
       eatSound.currentTime = 0;
       eatSound.play();
         if (a.type === 'speed') {
@@ -682,11 +702,6 @@ window.addEventListener('keyup', e => {
   }
 });
 
-difficultySelect.addEventListener('change', () => {
-  currentDifficulty = difficultySelect.value;
-  if (!running) reset();
-  renderLeaderboard();
-});
 
 themeSelect.addEventListener('change', () => {
   currentTheme = themes[themeSelect.value] || themes.classic;

--- a/style.css
+++ b/style.css
@@ -110,7 +110,7 @@ h1 {
   border-radius: 5px;
   display: none;
 }
-# options for difficulty and theme
+# options for theme and mode
 #options {
   margin: 10px;
 }


### PR DESCRIPTION
## Summary
- remove difficulty dropdown from UI
- describe auto-increasing difficulty in README
- auto-adjust difficulty as score rises
- update styles for options block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f70051628832a9bd516a908c79b50