### PR TITLE
Enable mouse clicks on touch buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open `index.html` in your browser or enable GitHub Pages on this repository to p
 
 Use the arrow keys or WASD keys to control the snake. Eat apples to grow longer and increase your score. Some apples are gold and grant bonus points. The snake wraps around when it reaches the edge of the board. Avoid your own tail and the obstacles that appear on higher difficulties.
 Hold the spacebar to temporarily speed up the snake. Press <kbd>p</kbd> to pause or resume the game. Difficulty now increases automatically as you score, so just choose a theme before starting.
-You can also enter your name to record it on the local leaderboard and use the on-screen **Pause** button if you prefer the mouse.
+You can also enter your name to record it on the local leaderboard and use the on-screen **Pause** or arrow buttons with a mouse or touch.
 
 Your highest scores are stored locally and displayed in the leaderboard below the game. The game will also try to fetch and submit online scores when possible.
 

--- a/script.js
+++ b/script.js
@@ -773,10 +773,12 @@ pauseButton.addEventListener('click', () => {
 });
 
 function attachTouch(el, dir) {
-  el.addEventListener('touchstart', e => {
+  const handler = e => {
     e.preventDefault();
     setDirection(dir);
-  });
+  };
+  el.addEventListener('touchstart', handler);
+  el.addEventListener('click', handler);
   el.addEventListener('touchend', e => e.preventDefault());
 }
 
@@ -788,7 +790,7 @@ if (upBtn) {
 }
 
 if (pauseTouchBtn) {
-  pauseTouchBtn.addEventListener('touchstart', e => {
+  const handlePause = e => {
     e.preventDefault();
     if (!running) return;
     paused = !paused;
@@ -796,6 +798,8 @@ if (pauseTouchBtn) {
     if (!paused) {
       requestAnimationFrame(gameLoop);
     }
-  });
+  };
+  pauseTouchBtn.addEventListener('touchstart', handlePause);
+  pauseTouchBtn.addEventListener('click', handlePause);
   pauseTouchBtn.addEventListener('touchend', e => e.preventDefault());
 }


### PR DESCRIPTION
## Summary
- support mouse clicks for touch controls
- mention using touch buttons with mouse clicks in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f772fb208832abf2ceadc62a7b182