### PR TITLE
Add service worker for offline PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,7 @@ Example remote config JSON:
 ```
 
 Removing the calls to `postScoreOnline` will disable online score submission entirely.
+
+## Installing as a PWA
+
+Snek includes a simple service worker so the game can be installed as a Progressive Web App. Open `index.html` in a browser that supports PWAs and choose the install option when prompted or from the browser menu. Once installed, the game will run offline using cached assets.

--- a/index.html
+++ b/index.html
@@ -46,5 +46,10 @@
     </div>
   </div>
   <script type="module" src="script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+  </script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,34 @@
+const CACHE_NAME = 'snek-cache-v1';
+const URLS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/script.js',
+  '/game.js',
+  '/asset_loader.js',
+  '/http_client.js',
+  '/remote_config.js',
+  '/scores.js',
+  '/assets/eat.mp3',
+  '/assets/gameover.mp3'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- create `service-worker.js` to cache static assets
- register service worker in `index.html`
- document how to install the game as a PWA

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc5b6b62c832aa118dd2428378549