### PR TITLE
Update layout for leaderboard

### DIFF
--- a/style.css
+++ b/style.css
@@ -177,7 +177,12 @@ h1 {
   }
   #sidebar {
     text-align: left;
-    margin-left: 20px;
+    order: 1;
+    margin-right: 20px;
+    margin-left: 0;
+  }
+  #game-wrapper {
+    order: 2;
   }
   #leaderboard {
     margin-left: 0;


### PR DESCRIPTION
## Summary
- make the leaderboard/controls sidebar appear on the left of the game board on wide screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404b2ce02c832aa2d6fd73149990fd