### PR TITLE
Increase apple spawn rate

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,12 +67,14 @@ window.addEventListener('resize', () => {
 });
 
 resizeCanvas();
-const appleCount = 3;
+// Start with more apples on the board
+const appleCount = 5;
 const NPC_COUNT = 3;
 const NPC_SPAWN_MIN = 2000; // minimum respawn delay in ms
 const NPC_SPAWN_MAX = 5000; // maximum respawn delay in ms
-const APPLE_SPAWN_MIN = 4000; // minimum new apple delay in ms
-const APPLE_SPAWN_MAX = 7000; // maximum new apple delay in ms
+// Spawn new apples more frequently
+const APPLE_SPAWN_MIN = 2000; // minimum new apple delay in ms
+const APPLE_SPAWN_MAX = 3500; // maximum new apple delay in ms
 
 function randomEmptyPosition() {
   const maxAttempts = 100;


### PR DESCRIPTION
## Summary
- spawn more apples at the start of the game
- decrease the delay between apple spawns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68407112d0b0832ab1038b1292bb766b