### PR TITLE
Add expandable leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
       <div id="sidebar">
         <h2>Leaderboard</h2>
         <ol id="leaderboard"></ol>
+        <button id="toggle-leaderboard" aria-expanded="false">Show Top 10</button>
       </div>
       <div id="controls">
         <label for="player-name">Name:</label>

--- a/script.js
+++ b/script.js
@@ -15,6 +15,8 @@ const rightBtn = document.getElementById('btn-right');
 const pauseTouchBtn = document.getElementById('btn-pause');
 const playerNameInput = document.getElementById('player-name');
 const leaderboardEl = document.getElementById('leaderboard');
+const toggleLbBtn = document.getElementById('toggle-leaderboard');
+let leaderboardExpanded = false;
 const gameOverEl = document.getElementById('game-over');
 const pausedEl = document.getElementById('paused');
 const themeSelect = document.getElementById('theme');
@@ -255,11 +257,17 @@ function renderLeaderboard() {
   const scores = loadLeaderboard();
   const list = scores[currentDifficulty] || [];
   leaderboardEl.innerHTML = '';
-  list.forEach((s, i) => {
+  const limit = leaderboardExpanded ? 10 : 5;
+  list.slice(0, limit).forEach((s, i) => {
     const li = document.createElement('li');
     li.textContent = `${i + 1}. ${s.name}: ${s.score}`;
     leaderboardEl.appendChild(li);
   });
+  if (toggleLbBtn) {
+    toggleLbBtn.style.display = list.length > 5 ? 'block' : 'none';
+    toggleLbBtn.textContent = leaderboardExpanded ? 'Show Top 5' : 'Show Top 10';
+    toggleLbBtn.setAttribute('aria-expanded', leaderboardExpanded);
+  }
   if (onlineScores.length) {
     const header = document.createElement('li');
     header.textContent = '--- Online ---';
@@ -733,6 +741,13 @@ reset();
 renderLeaderboard();
 loadOnlineLeaderboard();
 flushScores(SCORE_API);
+if (toggleLbBtn) {
+  toggleLbBtn.addEventListener('click', () => {
+    leaderboardExpanded = !leaderboardExpanded;
+    leaderboardEl.classList.toggle('expanded', leaderboardExpanded);
+    renderLeaderboard();
+  });
+}
 startButton.addEventListener('click', () => {
   // give the snake an initial direction so it doesn't immediately
   // collide with itself when the game starts

--- a/style.css
+++ b/style.css
@@ -75,8 +75,15 @@ button:hover {
   max-width: 200px;
   margin: 10px auto;
   text-align: left;
-  max-height: 200px;
+  max-height: 120px;
   overflow: hidden;
+  transition: max-height 0.3s ease;
+}
+#leaderboard.expanded {
+  max-height: 240px;
+}
+#toggle-leaderboard {
+  margin-top: 5px;
 }
 #leaderboard li {
   margin: 2px 0;


### PR DESCRIPTION
## Summary
- add 'Show Top 10' button
- make leaderboard height expandable
- support expanded display in script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840990442c0832a8a1f60f8bcfaad31