### PR TITLE
Add apple drops on NPC death

### DIFF
--- a/script.js
+++ b/script.js
@@ -355,6 +355,12 @@ function updateDifficulty() {
 
 function removeNpc(npc) {
   npcs = npcs.filter(n => n !== npc);
+  // drop apples where the NPC segments were
+  for (const part of npc.snake) {
+    if (!isOccupied(part.x, part.y, snake.concat(getAllNpcParts()), apples, obstacles)) {
+      apples.push({ x: part.x, y: part.y, type: 'normal' });
+    }
+  }
   updateScore();
   scheduleNpcSpawn();
 }


### PR DESCRIPTION
## Summary
- drop apples where an NPC snake dies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a2a0e5e0832a8f51301c5296c3b7