### PR TITLE
Add terminal log and fix leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
       <div id="sidebar">
         <h2>Leaderboard</h2>
         <ol id="leaderboard"></ol>
-        <button id="toggle-leaderboard" aria-expanded="false">Show Top 10</button>
       </div>
       <div id="controls">
         <label for="player-name">Name:</label>
@@ -46,12 +45,12 @@
         </div>
       </div>
     </div>
+    <pre id="terminal-log" class="terminal-log"></pre>
   <script type="module" src="script.js"></script>
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('service-worker.js');
     }
   </script>
-  <pre id="dev-log" class="dev-log"></pre>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -75,15 +75,8 @@ button:hover {
   max-width: 200px;
   margin: 10px auto;
   text-align: left;
-  max-height: 120px;
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-}
-#leaderboard.expanded {
   max-height: 240px;
-}
-#toggle-leaderboard {
-  margin-top: 5px;
+  overflow: hidden;
 }
 #leaderboard li {
   margin: 2px 0;
@@ -241,8 +234,7 @@ body.neon #leaderboard li {
   }
 }
 
-.dev-log {
-  display: none;
+.terminal-log {
   background: #000;
   color: #0f0;
   padding: 10px;
@@ -251,5 +243,5 @@ body.neon #leaderboard li {
   overflow: auto;
   text-align: left;
   width: 90%;
-  margin: 0 auto;
+  margin: 10px auto 0 auto;
 }


### PR DESCRIPTION
## Summary
- add a visible terminal-like log below the game
- remove leaderboard toggle and always show the top 10
- log key game events so players can see behind-the-scenes actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a4c1b0e8832a845fb48992846dae