### PR TITLE
Fix CI by using npm install

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 18
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Summary
- use `npm install` in Node workflow instead of `npm ci`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a78f9f60832ab87b37698e7d7f32